### PR TITLE
Bugfix/handle deletion failure

### DIFF
--- a/FileDeletionService/DiskType.cs
+++ b/FileDeletionService/DiskType.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using FileDeletionService;
-
-namespace FileDeletionService
+﻿namespace FileDeletionService
 {
     internal class DiskType
     {

--- a/FileDeletionService/FileDeletionManager.cs
+++ b/FileDeletionService/FileDeletionManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -153,7 +153,7 @@ namespace FileDeletionService
             {
                 _tokenSource?.Cancel();
             }
-            catch (Exception)
+            catch (Exception ex)
             {
                 errorCode = FileDeletionServiceErrorCodes.StoppingDeletion;
             }
@@ -220,8 +220,15 @@ namespace FileDeletionService
                                 if (totalBytesDeleted < minimumFreeSpaceRequiredInBytes - freeSpaceInBytes ||
                                     totalBytesDeleted < usedSpaceInBytes - maximumUsedSpaceInBytes)
                                 {
-                                    totalBytesDeleted += fileInfosList[i].Length;
-                                    fileInfosList[i].Delete();
+                                    try
+                                    {
+                                        fileInfosList[i].Delete();
+                                        totalBytesDeleted += fileInfosList[i].Length;
+                                    }
+                                    catch (Exception ex)
+                                    {
+                                        // unable to delete
+                                    }
                                 }
                                 else
                                     break;
@@ -271,8 +278,20 @@ namespace FileDeletionService
                             break;
                     }
 
+
+
                     if (toBeDeleted == true)
-                        fileInfo.Delete();
+                    {
+                        try
+                        {
+                            fileInfo.Delete();
+                        }
+                        catch (Exception ex)
+                        {
+                            // unable to delete
+                            usedSpaceInBytes += fileInfo.Length;
+                        }
+                    }
                     else
                         usedSpaceInBytes += fileInfo.Length;
                 }

--- a/FileDeletionService/FileDeletionManager.cs
+++ b/FileDeletionService/FileDeletionManager.cs
@@ -1,12 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using FileDeletionService;
-
-namespace FileDeletionService
+﻿namespace FileDeletionService
 {
     /// <summary>
     /// File deletion manager

--- a/FileDeletionService/FileType.cs
+++ b/FileDeletionService/FileType.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.IO;
-using System.Linq;
-using FileDeletionService;
-
-namespace FileDeletionService
+﻿namespace FileDeletionService
 {
     internal class FileType
     {

--- a/FileDeletionService/FolderType.cs
+++ b/FileDeletionService/FolderType.cs
@@ -1,9 +1,4 @@
-﻿using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using FileDeletionService;
-
-namespace FileDeletionService
+﻿namespace FileDeletionService
 {
     internal class FolderType
     {

--- a/FileDeletionService_Test/MainWindow.xaml.cs
+++ b/FileDeletionService_Test/MainWindow.xaml.cs
@@ -1,6 +1,5 @@
-﻿using System.Windows;
-using System.Windows.Threading;
-using FileDeletionService;
+﻿using FileDeletionService;
+using System.Windows;
 
 namespace FileDeletionService_Test
 {


### PR DESCRIPTION
A file failing to delete would result in skipping the deletion of subsequent files.
Examples:

- `fileInfo.Delete();` in `DeleteInsideFolderIterative`
- `fileInfosList[i].Delete();` in `Delete`

could raise exception _System.IO.IOException: 'The process cannot access the file 'XXX' because it is being used by another process.'_ resulting in the execution jumping to `Delete()` catch block `errorCode = FileDeletionServiceErrorCodes.Deletion;`, hence interrupting the periodic run.
Very likely the next periodic run would incur in the same behaviour, unless some system-level conditions have changed.
